### PR TITLE
feat: udistrital/sga_documentacion#105 Incluir carpeta resources en la imagen Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get install libmcrypt-dev -y
 
 RUN pip install awscli
 WORKDIR /
+COPY resources resources
 COPY entrypoint.sh entrypoint.sh
 COPY main main
 COPY conf/app.conf conf/app.conf


### PR DESCRIPTION
Este pull request modifica el Dockerfile para incluir la carpeta 'resources' en la imagen Docker. Se ha añadido la instrucción COPY para copiar la carpeta resources en la raíz del contenedor. Este cambio es necesario para asegurar que todos los recursos necesarios estén disponibles en el contenedor, mejorando así la funcionalidad y la confiabilidad de la aplicación en entornos de despliegue.

--- 

udistrital/sga_documentacion#105